### PR TITLE
Use different flavor for trove instances

### DIFF
--- a/trove.tf
+++ b/trove.tf
@@ -8,8 +8,8 @@ variable "network_uuid" {
 variable "db_flavor_uuid" {
   type = map(any)
   default = {
-    "codfw1dev" = "b1c8399c-87da-4262-86af-dfb6552e550e"
-    "eqiad1"    = "b204f489-f1a5-4d91-9a11-af1ae8b66bea"
+    "codfw1dev" = "0e38db8b-e6bb-49e1-82d8-e38a4e914caa"
+    "eqiad1"    = "41f0ea41-75ca-44a6-be66-bb56b2a90721"
   }
 }
 variable "region" {


### PR DESCRIPTION
MariaDB datastore requires a flavor with at least 2GB of RAM.

https://wikitech.wikimedia.org/wiki/Help:Trove_database_user_guide#Flavor_is_not_supported_for_datastore_version_(HTTP_400)